### PR TITLE
[LBA6-167] LDM facultative sur candid offres

### DIFF
--- a/ui/components/ItemDetail/CandidatureSpontanee/CandidatureSpontanee.test.js
+++ b/ui/components/ItemDetail/CandidatureSpontanee/CandidatureSpontanee.test.js
@@ -95,7 +95,7 @@ describe("CandidatureSpontanee", () => {
     fireEvent.click(submit);
     // Then
     await waitFor(() => {
-      expect(screen.getByTestId("fieldset-message")).toHaveClass("is-valid-false");
+      expect(screen.getByTestId("fieldset-message")).not.toHaveClass("is-valid-false");
       expect(screen.getByTestId("fieldset-firstname")).toHaveClass("is-valid-false");
       expect(screen.getByTestId("fieldset-lastname")).toHaveClass("is-valid-false");
       expect(screen.getByTestId("fieldset-email")).toHaveClass("is-valid-false");

--- a/ui/components/ItemDetail/CandidatureSpontanee/services/getSchema.js
+++ b/ui/components/ItemDetail/CandidatureSpontanee/services/getSchema.js
@@ -24,14 +24,7 @@ const commonControls = {
 };
 
 export function getValidationSchema(actualKind) {
-  if (actualKind === "matcha") {
-    return Yup.object({
-      message: Yup.string().nullable().required("⚠ La lettre de motivation est obligatoire"),
-      ...commonControls,
-    });
-  } else {
     return Yup.object({
       ...commonControls,
     });
-  }
 }


### PR DESCRIPTION
@alanlr l'objectif de cette PR est, au sein du formulaire de candidature à une offre Matcha, de rendre facultatif le message personnalisé que peut envoyer l'usager au responsable du recrutement.
J'ai l'impression qu'il faut seulement mettre à jour cette fonction, mais une vérification serait profitable o:)